### PR TITLE
feat: PDF export and code block fix (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to PM Toolkit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-02-16
+
+### Fixed
+
+- Code blocks with blank lines (e.g., two class definitions separated by a blank line) no longer split into separate blocks when loaded or pasted
+
 ## [0.7.0] - 2026-02-16
 
 ### Added
@@ -16,10 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configurable page size (A4, Letter, Legal, Tabloid), margins, and background printing
   - PDF saved next to the source `.md` file with "Open File" / "Open Folder" actions
   - Manual browser path override via `pmtoolkit.pdfChromePath` setting
-
-### Fixed
-
-- Code blocks with blank lines (e.g., two class definitions separated by a blank line) no longer split into separate blocks when pasted
 
 ## [0.6.0] - 2026-02-08
 
@@ -242,6 +244,7 @@ The biggest release yet. The entire editor has been rebuilt on React 18, images 
 
 - **Custom File Icons**: Kanban files show dedicated icon in file explorer
 
+[0.7.1]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.7.1
 [0.7.0]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.7.0
 [0.6.0]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.6.0
 [0.5.0]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to PM Toolkit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-02-16
+
+### Added
+
+- **PDF Export** — Export any markdown document to a pixel-perfect PDF via Command Palette or the editor title bar
+  - Uses Chrome's rendering engine (via `puppeteer-core`) for output identical to the editor
+  - Selectable text, proper tables, images, and Mermaid SVG diagrams
+  - Auto-detects Chrome, Chromium, Edge, or Brave on macOS, Windows, and Linux
+  - Configurable page size (A4, Letter, Legal, Tabloid), margins, and background printing
+  - PDF saved next to the source `.md` file with "Open File" / "Open Folder" actions
+  - Manual browser path override via `pmtoolkit.pdfChromePath` setting
+
+### Fixed
+
+- Code blocks with blank lines (e.g., two class definitions separated by a blank line) no longer split into separate blocks when pasted
+
 ## [0.6.0] - 2026-02-08
 
 The biggest release yet. The entire editor has been rebuilt on React 18, images and tables got ground-up redesigns, and new features like block handles, document outline, and save validation make PM Toolkit feel like a proper writing tool.
@@ -226,6 +242,7 @@ The biggest release yet. The entire editor has been rebuilt on React 18, images 
 
 - **Custom File Icons**: Kanban files show dedicated icon in file explorer
 
+[0.7.0]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.7.0
 [0.6.0]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.6.0
 [0.5.0]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.5.0
 [0.4.7]: https://github.com/aaronkwhite/pm-toolkit/releases/tag/v0.4.7

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Type `/` for slash commands. Select text for instant formatting. Drag in images.
 - **Mermaid diagrams** — Flowcharts, sequence diagrams, and more render inline with fit-to-view
 - **Templates** — Create reusable document templates and insert them via `/` commands
 - **Task lists** — Interactive checkboxes that save to standard markdown syntax
+- **PDF export** — Export any document to a pixel-perfect PDF via Command Palette or the title bar button
 - **Smart navigation** — Arrow keys and Cmd+Enter move through code blocks and tables naturally
 
 ### Tasks without context switching
@@ -134,6 +135,16 @@ Create reusable document templates that appear in the slash command menu.
 
 Templates are regular markdown files. The filename becomes the template name in the menu.
 
+### PDF Export
+
+Export any markdown document to PDF — the output looks identical to the editor.
+
+1. Open a `.md` file in PM Toolkit
+2. Run **PM Toolkit: Export to PDF** from the Command Palette, or click the PDF icon in the editor title bar
+3. The PDF is saved next to your `.md` file
+
+Requires Chrome, Chromium, Edge, or Brave installed (auto-detected). Set a custom path with `pmtoolkit.pdfChromePath` if needed.
+
 ## Configuration
 
 Access settings via the **PM Toolkit Settings** command (from the editor `...` menu or Command Palette), or through `Code` → `Settings` → `Extensions` → `PM Toolkit`.
@@ -147,6 +158,10 @@ Access settings via the **PM Toolkit Settings** command (from the editor `...` m
 | `pmtoolkit.kanbanShowThumbnails` | Show image thumbnails on kanban cards | true |
 | `pmtoolkit.kanbanSaveDelay` | Delay before saving kanban changes (50-2000ms) | 150 |
 | `pmtoolkit.imageAssetsPath` | Directory where uploaded images are saved (relative to the document) | assets |
+| `pmtoolkit.pdfChromePath` | Path to Chrome/Chromium for PDF export (auto-detected if empty) | — |
+| `pmtoolkit.pdfPageSize` | Page size for PDF export | A4 |
+| `pmtoolkit.pdfMarginTop` / `Bottom` / `Left` / `Right` | PDF margins | 20mm / 20mm / 15mm / 15mm |
+| `pmtoolkit.pdfPrintBackground` | Include background colors in PDF (e.g., code blocks) | true |
 
 ## Built With
 
@@ -163,6 +178,7 @@ PM Toolkit is built on solid open-source foundations:
 | [Mammoth](https://github.com/mwilliamson/mammoth.js) | Word document conversion | BSD-2 |
 | [SheetJS](https://sheetjs.com) | Excel parsing | Apache 2.0 |
 | [Papa Parse](https://www.papaparse.com) | CSV parsing | MIT |
+| [Puppeteer](https://pptr.dev) | PDF export (puppeteer-core) | Apache 2.0 |
 
 ## Contributing
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -34,7 +34,7 @@ const extensionConfig = {
   platform: 'node',
   target: 'node18',
   outfile: 'dist/extension.js',
-  external: ['vscode'],
+  external: ['vscode', 'puppeteer-core'],
   sourcemap: !production,
   minify: production,
   plugins: [buildStatusPlugin],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pm-toolkit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-toolkit",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/dom": "^0.1.2",
@@ -30,6 +30,7 @@
         "mermaid": "^11.4.0",
         "papaparse": "^5.4.1",
         "pdfjs-dist": "^4.9.155",
+        "puppeteer-core": "^24.37.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tiptap-markdown": "^0.8.10",
@@ -1313,6 +1314,66 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.1.tgz",
+      "integrity": "sha512-fXa6uXLxfslBlus3MEpW8S6S9fe5RwmAE5Gd8u3krqOwnkZJV3/lQJiY3LaFdTctLLqJtyMgEUGkbDnRNf6vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/b4a": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.4.tgz",
+      "integrity": "sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
@@ -2147,6 +2208,12 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2493,7 +2560,7 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2617,6 +2684,16 @@
       "integrity": "sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.2",
@@ -2873,7 +2950,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2929,7 +3005,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3032,6 +3107,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3086,6 +3173,97 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.4.tgz",
+      "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3105,6 +3283,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.52",
@@ -3311,7 +3498,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3527,6 +3713,71 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -3560,7 +3811,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3573,7 +3823,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4312,6 +4561,15 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -4322,7 +4580,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4407,6 +4664,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -4457,6 +4728,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1566079",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -4653,7 +4930,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4684,7 +4960,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4805,6 +5080,15 @@
         "@esbuild/win32-x64": "0.24.2"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4824,6 +5108,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4837,6 +5142,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -4845,6 +5168,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/exceljs": {
@@ -4970,6 +5302,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-csv": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
@@ -4988,6 +5340,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5038,7 +5396,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -5266,6 +5623,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5305,6 +5671,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
@@ -5316,6 +5697,20 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/github-from-package": {
@@ -5597,7 +5992,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -5611,7 +6005,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5718,6 +6111,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5767,7 +6169,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6624,6 +7025,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -6661,7 +7068,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -6706,6 +7112,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-abi": {
@@ -6832,7 +7247,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6880,6 +7294,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -7116,7 +7562,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7247,6 +7692,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
@@ -7457,20 +7911,45 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7483,6 +7962,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.37.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.3.tgz",
+      "integrity": "sha512-fokQ8gv+hNgsRWqVuP5rUjGp+wzV5aMTP3fcm8ekNabmLGlJdFHas1OdMscAH9Gzq4Qcf7cfI/Pe6wEcAqQhqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.12.1",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1566079",
+        "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/qs": {
@@ -7714,6 +8211,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -7962,10 +8468,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8237,6 +8742,54 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -8301,6 +8854,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8320,7 +8884,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8374,7 +8937,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8384,7 +8946,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8600,6 +9161,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.6.tgz",
+      "integrity": "sha512-27FeW5GQFDfw0FpwMQhMagB7BztOOlmjcSRi97t2oplhKVTZtp0DZbSegSaXS5IIC6mxMvBG4AR1Sgc6BX3CQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.4.tgz",
+      "integrity": "sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-table": {
@@ -9301,6 +9885,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
     "node_modules/typed-rest-client": {
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
@@ -9359,7 +9949,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-properties": {
@@ -9594,6 +10184,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -9754,8 +10350,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -9854,6 +10470,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -9861,11 +10486,37 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -9954,6 +10605,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pm-toolkit",
   "displayName": "PM Toolkit",
   "description": "Visual markdown editor, kanban boards, and file viewers — right where you code.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publisher": "aaronkwhite",
   "license": "MIT",
   "icon": "images/pm-toolkit-icon-light.png",

--- a/package.json
+++ b/package.json
@@ -160,6 +160,12 @@
         "title": "PM Toolkit Settings",
         "category": "PM Toolkit",
         "icon": "$(gear)"
+      },
+      {
+        "command": "pmtoolkit.exportToPdf",
+        "title": "Export to PDF",
+        "category": "PM Toolkit",
+        "icon": "$(file-pdf)"
       }
     ],
     "menus": {
@@ -171,6 +177,11 @@
         }
       ],
       "editor/title": [
+        {
+          "command": "pmtoolkit.exportToPdf",
+          "when": "activeCustomEditorId == pmtoolkit.markdownEditor",
+          "group": "1_modification"
+        },
         {
           "command": "pmtoolkit.openSettings",
           "when": "activeCustomEditorId =~ /pmtoolkit\\./",
@@ -231,6 +242,47 @@
           "type": "boolean",
           "default": true,
           "description": "Show image thumbnails on kanban cards by default"
+        },
+        "pmtoolkit.pdfChromePath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to Chrome/Chromium executable for PDF export (auto-detected if empty)"
+        },
+        "pmtoolkit.pdfPageSize": {
+          "type": "string",
+          "default": "A4",
+          "enum": [
+            "A4",
+            "Letter",
+            "Legal",
+            "Tabloid"
+          ],
+          "description": "Page size for PDF export"
+        },
+        "pmtoolkit.pdfMarginTop": {
+          "type": "string",
+          "default": "20mm",
+          "description": "Top margin for PDF export"
+        },
+        "pmtoolkit.pdfMarginBottom": {
+          "type": "string",
+          "default": "20mm",
+          "description": "Bottom margin for PDF export"
+        },
+        "pmtoolkit.pdfMarginLeft": {
+          "type": "string",
+          "default": "15mm",
+          "description": "Left margin for PDF export"
+        },
+        "pmtoolkit.pdfMarginRight": {
+          "type": "string",
+          "default": "15mm",
+          "description": "Right margin for PDF export"
+        },
+        "pmtoolkit.pdfPrintBackground": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include background colors/images in PDF export (e.g., code block backgrounds)"
         }
       }
     }
@@ -268,6 +320,7 @@
     "mermaid": "^11.4.0",
     "papaparse": "^5.4.1",
     "pdfjs-dist": "^4.9.155",
+    "puppeteer-core": "^24.37.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tiptap-markdown": "^0.8.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pm-toolkit",
   "displayName": "PM Toolkit",
   "description": "Visual markdown editor, kanban boards, and file viewers — right where you code.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "aaronkwhite",
   "license": "MIT",
   "icon": "images/pm-toolkit-icon-light.png",

--- a/src/export/PdfExporter.ts
+++ b/src/export/PdfExporter.ts
@@ -1,0 +1,369 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import puppeteer from 'puppeteer-core';
+
+/**
+ * Platform-specific Chrome/Chromium executable paths to search
+ */
+const CHROME_PATHS: Record<string, string[]> = {
+  darwin: [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+  ],
+  win32: [
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    `${process.env.LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`,
+    'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+    'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+    `${process.env.LOCALAPPDATA}\\Microsoft\\Edge\\Application\\msedge.exe`,
+    'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+    `${process.env.LOCALAPPDATA}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
+  ],
+  linux: [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/snap/bin/chromium',
+    '/usr/bin/microsoft-edge',
+    '/usr/bin/brave-browser',
+  ],
+};
+
+/**
+ * Find Chrome/Chromium executable on the current platform
+ */
+function findChromePath(): string | undefined {
+  const platform = process.platform;
+  const candidates = CHROME_PATHS[platform] || CHROME_PATHS.linux;
+
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve Chrome path: user setting → auto-detect → error
+ */
+function resolveChromePath(): string {
+  const config = vscode.workspace.getConfiguration('pmtoolkit');
+  const userPath = config.get<string>('pdfChromePath', '');
+
+  if (userPath) {
+    if (fs.existsSync(userPath)) {
+      return userPath;
+    }
+    throw new Error(
+      `Chrome path from settings not found: ${userPath}\n\nUpdate pmtoolkit.pdfChromePath in settings.`
+    );
+  }
+
+  const detected = findChromePath();
+  if (detected) {
+    return detected;
+  }
+
+  throw new Error(
+    'Could not find Chrome, Chromium, Edge, or Brave.\n\n' +
+    'Install one of these browsers, or set the path manually:\n' +
+    'Settings → pmtoolkit.pdfChromePath'
+  );
+}
+
+/**
+ * CSS variable replacements for print-friendly output.
+ * These replace VS Code theme variables with hardcoded light-theme values
+ * suitable for PDF output.
+ */
+const CSS_VAR_REPLACEMENTS: Record<string, string> = {
+  '--vscode-editor-background': '#ffffff',
+  '--vscode-editor-foreground': '#1e1e1e',
+  '--vscode-foreground': '#1e1e1e',
+  '--vscode-font-family': "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+  '--vscode-editor-font-family': "'SF Mono', Monaco, Menlo, Consolas, monospace",
+  '--vscode-font-size': '14px',
+  '--vscode-textLink-foreground': '#0969da',
+  '--vscode-textLink-activeForeground': '#0550ae',
+  '--vscode-textBlockQuote-border': '#d0d7de',
+  '--vscode-textBlockQuote-background': '#f6f8fa',
+  '--vscode-textCodeBlock-background': '#f6f8fa',
+  '--vscode-panel-border': '#d0d7de',
+  '--vscode-focusBorder': '#0969da',
+  '--vscode-editor-lineHighlightBackground': '#f6f8fa',
+  '--vscode-input-placeholderForeground': '#6e7781',
+  '--vscode-descriptionForeground': '#6e7781',
+  '--vscode-errorForeground': '#cf222e',
+  '--vscode-inputValidation-errorBackground': '#ffebe9',
+  '--vscode-inputValidation-errorBorder': '#cf222e',
+  '--vscode-list-hoverBackground': '#f3f4f6',
+  '--vscode-list-activeSelectionBackground': '#0969da',
+  '--vscode-list-activeSelectionForeground': '#ffffff',
+  '--vscode-button-background': '#0969da',
+  '--vscode-button-foreground': '#ffffff',
+  '--vscode-button-hoverBackground': '#0550ae',
+  '--vscode-menu-background': '#ffffff',
+  '--vscode-menu-foreground': '#1e1e1e',
+  '--vscode-menu-border': '#d0d7de',
+  '--vscode-editorWidget-background': '#ffffff',
+  '--vscode-editorWidget-border': '#d0d7de',
+  '--vscode-scrollbarSlider-background': 'rgba(0, 0, 0, 0.1)',
+  '--vscode-toolbar-hoverBackground': 'rgba(0, 0, 0, 0.05)',
+  '--vscode-editor-hoverHighlightBackground': 'rgba(0, 0, 0, 0.04)',
+  '--vscode-input-background': '#ffffff',
+  '--vscode-input-foreground': '#1e1e1e',
+  '--vscode-input-border': '#d0d7de',
+  '--vscode-button-secondaryBackground': '#f3f4f6',
+  '--vscode-button-secondaryForeground': '#1e1e1e',
+  '--vscode-menu-selectionBackground': '#0969da',
+  '--vscode-menu-selectionForeground': '#ffffff',
+};
+
+/**
+ * Replace CSS var() references with hardcoded values for PDF rendering.
+ *
+ * Strategy:
+ * 1. Replace known VS Code CSS variables with print-friendly values
+ * 2. For any remaining var() with a fallback, extract the fallback value
+ * 3. For color-mix() using CSS vars, simplify to the fallback
+ */
+function replaceCssVariables(css: string): string {
+  let result = css;
+
+  // Replace known variables: var(--vscode-foo) → value
+  // Also handles: var(--vscode-foo, fallback) → value
+  for (const [varName, value] of Object.entries(CSS_VAR_REPLACEMENTS)) {
+    // Match var(--name) or var(--name, fallback)
+    const escaped = varName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`var\\(${escaped}(?:,\\s*[^)]+)?\\)`, 'g');
+    result = result.replace(pattern, value);
+  }
+
+  // Handle pmtoolkit custom vars that reference theme vars
+  result = result.replace(
+    /--pmtoolkit-accent:\s*var\([^)]+\);/g,
+    '--pmtoolkit-accent: #0969da;'
+  );
+  result = result.replace(
+    /--pmtoolkit-accent-bg:\s*[^;]+;/g,
+    '--pmtoolkit-accent-bg: rgba(9, 105, 218, 0.15);'
+  );
+
+  // Catch-all: remaining var(--anything, fallback) → fallback
+  result = result.replace(
+    /var\(--[a-zA-Z0-9-]+,\s*([^)]+)\)/g,
+    (_match, fallback) => fallback.trim()
+  );
+
+  // Remaining var(--anything) with no fallback → remove gracefully
+  // (these would be theme vars we don't have a replacement for)
+  result = result.replace(/var\(--[a-zA-Z0-9-]+\)/g, 'inherit');
+
+  // Replace color-mix references that may still have var() inside
+  result = result.replace(
+    /color-mix\(in srgb,\s*inherit\s+(\d+%),\s*transparent\)/g,
+    (_match, pct) => `rgba(9, 105, 218, ${parseInt(pct) / 100})`
+  );
+
+  return result;
+}
+
+/**
+ * Resolve relative image paths in HTML to file:// URLs for Puppeteer.
+ * Handles data-original-src attributes from the editor.
+ */
+function resolveImagePaths(html: string, documentDir: string): string {
+  return html.replace(
+    /<img\s([^>]*?)src="([^"]+)"([^>]*?)>/g,
+    (match, before: string, src: string, after: string) => {
+      // Skip absolute URLs, data URIs, and file:// URLs
+      if (/^(https?:|data:|file:)/i.test(src)) {
+        return match;
+      }
+
+      // Check for data-original-src which has the real relative path
+      const originalSrcMatch = (before + after).match(/data-original-src="([^"]+)"/);
+      const relativePath = originalSrcMatch ? originalSrcMatch[1] : src;
+
+      // Skip if already absolute
+      if (/^(https?:|data:|file:)/i.test(relativePath)) {
+        return match;
+      }
+
+      const absolutePath = path.resolve(documentDir, relativePath);
+      const fileUrl = `file://${absolutePath}`;
+      return `<img ${before}src="${fileUrl}"${after}>`;
+    }
+  );
+}
+
+/**
+ * PDF-specific CSS to hide interactive elements and add print styling
+ */
+const PDF_CSS = `
+  /* Hide interactive elements */
+  .block-handle-container,
+  .document-outline,
+  .bubble-menu,
+  .image-resize-handle,
+  .image-popover-toolbar,
+  .table-add-row-bar,
+  .table-add-column-bar,
+  .table-row-grip,
+  .table-col-grip,
+  .table-grip-menu,
+  .table-selection-highlight,
+  .table-drop-indicator,
+  .table-size-picker,
+  .link-picker,
+  .slash-command-menu-container,
+  .mermaid-toolbar,
+  .mermaid-view-toggle,
+  .mermaid-edit,
+  .mermaid-textarea,
+  .block-drop-indicator,
+  .ProseMirror-gapcursor {
+    display: none !important;
+  }
+
+  /* Remove editor chrome */
+  #editor-wrapper {
+    padding-left: 0 !important;
+  }
+
+  .ProseMirror {
+    min-height: auto !important;
+  }
+
+  /* Page break hints */
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  table, pre, .mermaid-node, .image-node-view {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Ensure images fit within page */
+  img {
+    max-width: 100% !important;
+    height: auto !important;
+  }
+
+  /* Mermaid diagrams - ensure they render in fit mode */
+  .mermaid-diagram {
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .mermaid-diagram svg {
+    max-width: 100% !important;
+    height: auto !important;
+  }
+`;
+
+/**
+ * Build a standalone HTML document for PDF rendering
+ */
+export function prepareHtml(
+  htmlContent: string,
+  documentDir: string,
+  cssContent: string
+): string {
+  const processedCss = replaceCssVariables(cssContent);
+  const processedHtml = resolveImagePaths(htmlContent, documentDir);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>${processedCss}</style>
+  <style>${PDF_CSS}</style>
+</head>
+<body>
+  <div id="editor">
+    <div id="editor-wrapper">
+      <div class="ProseMirror">
+        ${processedHtml}
+      </div>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+export interface PdfExportOptions {
+  htmlContent: string;
+  documentUri: vscode.Uri;
+  cssContent: string;
+}
+
+/**
+ * Export editor HTML to PDF using puppeteer-core
+ */
+export async function exportToPdf(options: PdfExportOptions): Promise<string> {
+  const { htmlContent, documentUri, cssContent } = options;
+
+  const chromePath = resolveChromePath();
+  const documentDir = path.dirname(documentUri.fsPath);
+
+  // Build output path: same directory as source, .pdf extension
+  const baseName = path.basename(documentUri.fsPath, path.extname(documentUri.fsPath));
+  const pdfPath = path.join(documentDir, `${baseName}.pdf`);
+
+  // Get user settings
+  const config = vscode.workspace.getConfiguration('pmtoolkit');
+  const pageSize = config.get<string>('pdfPageSize', 'A4');
+  const marginTop = config.get<string>('pdfMarginTop', '20mm');
+  const marginBottom = config.get<string>('pdfMarginBottom', '20mm');
+  const marginLeft = config.get<string>('pdfMarginLeft', '15mm');
+  const marginRight = config.get<string>('pdfMarginRight', '15mm');
+  const printBackground = config.get<boolean>('pdfPrintBackground', true);
+
+  // Prepare HTML
+  const fullHtml = prepareHtml(htmlContent, documentDir, cssContent);
+
+  // Launch browser and generate PDF
+  const browser = await puppeteer.launch({
+    executablePath: chromePath,
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await browser.newPage();
+
+    // Allow file:// access for local images
+    await page.setContent(fullHtml, {
+      waitUntil: 'networkidle0',
+    });
+
+    // Generate PDF
+    await page.pdf({
+      path: pdfPath,
+      format: pageSize as any,
+      margin: {
+        top: marginTop,
+        bottom: marginBottom,
+        left: marginLeft,
+        right: marginRight,
+      },
+      printBackground,
+    });
+
+    return pdfPath;
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,8 @@ export type ExtensionToWebviewMessage =
   | { type: 'imageUrl'; payload: { originalPath: string; webviewUrl: string } }
   | { type: 'imageSaved'; payload: { originalPath: string; webviewUrl: string } }
   | { type: 'filePickerResult'; payload: { originalPath: string; webviewUrl: string } }
-  | { type: 'files'; payload: { files: FileInfo[]; currentFilePath: string } };
+  | { type: 'files'; payload: { files: FileInfo[]; currentFilePath: string } }
+  | { type: 'requestPdfExport' };
 
 /**
  * Messages sent from Webview to Extension
@@ -33,7 +34,8 @@ export type WebviewToExtensionMessage =
   | { type: 'saveImage'; payload: { filename: string; data: string } }
   | { type: 'requestFilePicker' }
   | { type: 'requestFiles'; payload: { search?: string } }
-  | { type: 'openFile'; payload: { path: string } };
+  | { type: 'openFile'; payload: { path: string } }
+  | { type: 'exportPdf'; payload: { htmlContent: string } };
 
 /**
  * Template definition from YAML frontmatter

--- a/webview/editor/Editor.tsx
+++ b/webview/editor/Editor.tsx
@@ -218,6 +218,25 @@ export function Editor({ initialContent = '', filename = 'untitled.md' }: Editor
           }
           break
         }
+
+        // PDF export request from extension
+        case 'requestPdfExport': {
+          let html = editor.getHTML()
+
+          // Replace mermaid code blocks with rendered SVGs from the DOM
+          const mermaidDiagrams = document.querySelectorAll('.mermaid-diagram svg')
+          const mermaidPres = html.match(/<pre[^>]*data-type="mermaid"[^>]*>[\s\S]*?<\/pre>/g) || []
+
+          mermaidDiagrams.forEach((svg, index) => {
+            if (mermaidPres[index]) {
+              const svgHtml = svg.outerHTML
+              html = html.replace(mermaidPres[index], `<div class="mermaid-diagram">${svgHtml}</div>`)
+            }
+          })
+
+          getVSCode().postMessage({ type: 'exportPdf', payload: { htmlContent: html } })
+          break
+        }
       }
     }
 

--- a/webview/editor/Editor.tsx
+++ b/webview/editor/Editor.tsx
@@ -25,6 +25,7 @@ import { SlashCommand, setTemplates } from './extensions/SlashCommand'
 import { ImageNode } from './extensions/ImageNode'
 import { MermaidNode } from './extensions/MermaidNode'
 import { TableControls } from './extensions/TableControls'
+import { MarkdownPaste } from './extensions/MarkdownPaste'
 
 // VS Code API type
 declare global {
@@ -117,9 +118,10 @@ export function Editor({ initialContent = '', filename = 'untitled.md' }: Editor
         bulletListMarker: '-',
         linkify: false,
         breaks: false,
-        transformPastedText: true,
+        transformPastedText: false,
         transformCopiedText: true,
       }),
+      MarkdownPaste,
       SlashCommand,
       KeyboardNavigation,
     ],

--- a/webview/editor/extensions/MarkdownPaste.ts
+++ b/webview/editor/extensions/MarkdownPaste.ts
@@ -1,0 +1,43 @@
+/**
+ * Custom paste handler that parses pasted markdown as a full document
+ * instead of inline. Fixes code blocks with blank lines being split
+ * into separate elements.
+ *
+ * tiptap-markdown's default clipboardTextParser uses inline parsing mode
+ * which runs normalizeInline() — that function can't handle block elements
+ * like <pre> and splits code blocks at blank lines.
+ */
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { DOMParser as PMDOMParser } from '@tiptap/pm/model'
+
+export const MarkdownPaste = Extension.create({
+  name: 'markdownPaste',
+
+  addProseMirrorPlugins() {
+    const editor = this.editor
+
+    return [
+      new Plugin({
+        key: new PluginKey('markdownPaste'),
+        props: {
+          clipboardTextParser(text, $context, plainText) {
+            if (plainText) return null
+
+            // Parse as full document (not inline) to preserve block elements
+            const parsed = editor.storage.markdown?.parser?.parse(text)
+            if (!parsed) return null
+
+            const element = document.createElement('div')
+            element.innerHTML = parsed
+
+            return PMDOMParser.fromSchema(editor.schema).parseSlice(element, {
+              preserveWhitespace: true,
+              context: $context,
+            })
+          },
+        },
+      }),
+    ]
+  },
+})


### PR DESCRIPTION
## Summary

- **PDF Export** — Export any markdown document to a pixel-perfect PDF via Command Palette or editor title bar. Uses `puppeteer-core` with Chrome auto-detection (Chrome, Chromium, Edge, Brave on macOS/Windows/Linux). Configurable page size, margins, and background printing.
- **Code block fix** — Code blocks containing blank lines (e.g., two class definitions separated by a blank line) no longer split into separate blocks when loaded or pasted. Root cause was a triple-parse through tiptap-markdown's overrides of both `setContent` and `insertContentAt`.

## New files
- `src/export/PdfExporter.ts` — Core PDF export module with browser detection, CSS variable replacement, image path resolution
- `webview/editor/extensions/MarkdownPaste.ts` — Custom paste handler for markdown code blocks

## Test plan
- [ ] Open a `.md` file with code blocks containing blank lines — verify they render as a single block
- [ ] Paste a code block with blank lines — verify it stays intact
- [ ] Run "PM Toolkit: Export to PDF" from Command Palette on a doc with headings, tables, code blocks, images, and Mermaid diagrams
- [ ] Verify PDF renders identically to the editor
- [ ] Click the PDF icon in the editor title bar — same result
- [ ] Test with Chrome not installed — verify helpful error message
- [ ] Test `pmtoolkit.pdfChromePath` setting override
- [ ] Test page size and margin settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)