### PR TITLE
feat: runtime-flag-driven v0.8.0 reveal for live demo

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,7 +1,11 @@
 ---
-import { getLatestPublicVersion } from '../lib/version';
+import { getLatestPublicVersion, getExpectedNextVersion } from '../lib/version';
 
 const { tag: version } = await getLatestPublicVersion();
+const { tag: nextVersion } = getExpectedNextVersion();
+const versionSuffix = ' · MIT licensed · open source';
+const defaultVersionText = `${version}${versionSuffix}`;
+const flagVersionText = `${nextVersion}${versionSuffix}`;
 ---
 
 <!-- Page-level grid: aurora wash + animated grid lines + mint pulses -->
@@ -52,8 +56,13 @@ const { tag: version } = await getLatestPublicVersion();
         </a>
       </div>
 
-      <!-- Version -->
-      <p class="hero-version-new" id="hero-version">{version} · MIT licensed · open source</p>
+      <!-- Version (text swapped at runtime by the PostHog feature-flag callback) -->
+      <p
+        class="hero-version-new"
+        id="hero-version"
+        data-version-text-default={defaultVersionText}
+        data-version-text-flag={flagVersionText}
+      >{defaultVersionText}</p>
 
       <!-- Hero screenshot -->
       <div class="hero-media-new" id="hero-media">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -183,9 +183,21 @@ const jsonLd = { '@context': 'https://schema.org', '@graph': graph };
                   var name = root.attributes[i].name;
                   if (name.indexOf('data-flag-') === 0) root.removeAttribute(name);
                 }
-                (flags || []).forEach(function(key) {
+                var active = flags || [];
+                active.forEach(function(key) {
                   root.setAttribute('data-flag-' + key, 'on');
                 });
+                // Hero version chip swap — the data-* attributes carry both
+                // the default and the flag-revealed text so this script does
+                // not need to know the format.
+                var heroVersion = document.getElementById('hero-version');
+                if (heroVersion) {
+                  var enabled = active.indexOf('site-show-v0-8') >= 0;
+                  var text = enabled
+                    ? heroVersion.getAttribute('data-version-text-flag')
+                    : heroVersion.getAttribute('data-version-text-default');
+                  if (text) heroVersion.textContent = text;
+                }
               });
             },
           });

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -14,6 +14,13 @@ const FAILSAFE_HIDDEN: readonly string[] = ['0.8.0'];
 
 const FALLBACK_VERSION = '0.7.3';
 
+// The next version that has shipped to GitHub-but-not-marketplaces, used to
+// pre-render an "alternate" hero version chip and changelog entry that the
+// `site-show-v0-8` PostHog flag can reveal at runtime without a rebuild.
+// Hardcoded because the GitHub releases API can't return a tag that doesn't
+// exist yet. Drop this constant when v0.8.0 ships to the marketplaces.
+const EXPECTED_NEXT_VERSION = '0.8.0';
+
 function strip(tag: string): string {
   return (tag || '').replace(/^v/, '');
 }
@@ -90,4 +97,13 @@ export async function getLatestPublicVersion(): Promise<VersionResult> {
     }
   } catch {}
   return { version: FALLBACK_VERSION, tag: `v${FALLBACK_VERSION}` };
+}
+
+/**
+ * The runtime-flag-revealed "next" version. Paired with `getLatestPublicVersion`
+ * so pages can render both the safe default and the flag-revealed value, then
+ * swap between them based on the `site-show-v0-8` PostHog flag.
+ */
+export function getExpectedNextVersion(): VersionResult {
+  return { version: EXPECTED_NEXT_VERSION, tag: `v${EXPECTED_NEXT_VERSION}` };
 }

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -60,12 +60,16 @@ for (const line of lines) {
 }
 if (currentEntry) currentEntry.intro = introLines.join('\n').trim();
 
-// Drop entries for versions that exist on GitHub but haven't shipped to the
-// VS Code Marketplace / Open VSX yet — the source CHANGELOG.md is pulled
-// from origin/main at prebuild time, so it can lead the marketplaces.
-// Hidden set comes from the `site-hidden-versions` PostHog flag payload.
+// Render ALL entries, but mark versions in the `site-hidden-versions` PostHog
+// flag payload with `cl-entry-hidden` so they're hidden by default via CSS.
+// The `site-show-v0-8` runtime flag flips them on without a rebuild — used
+// for live demos before v0.8.0 ships to the marketplaces.
 const hidden = await getHiddenVersions();
-const visibleEntries = entries.filter((e) => !hidden.has(e.version));
+// Find the index of the first entry that is NOT hidden — that's the one that
+// gets the "latest" pill in the default state. When the demo flag is enabled,
+// the first build-time-hidden entry effectively becomes "latest" via CSS.
+const firstVisibleIndex = entries.findIndex((e) => !hidden.has(e.version));
+const firstHiddenIndex = entries.findIndex((e) => hidden.has(e.version));
 
 function tagClass(name: string): string {
   switch (name.toLowerCase()) {
@@ -110,12 +114,18 @@ function formatDate(dateStr: string): string {
     <!-- Entries -->
     <section style="padding-top: 0; padding-bottom: clamp(64px, 8vw, 120px);">
       <div class="changelog-layout">
-        {visibleEntries.map((entry, i) => (
-          <article class="changelog-entry-new">
+        {entries.map((entry, i) => {
+          const isHidden = hidden.has(entry.version);
+          const isLatestDefault = i === firstVisibleIndex;
+          const isLatestWhenRevealed = i === firstHiddenIndex;
+          const articleClass = `changelog-entry-new${isHidden ? ' cl-entry-hidden' : ''}`;
+          return (
+          <article class={articleClass} data-changelog-version={entry.version}>
             <div class="changelog-meta-new">
               <div class="changelog-version-row">
                 <div class="changelog-version-new">v{entry.version}</div>
-                {i === 0 && <span class="cl-tag cl-tag-sm cl-tag-latest">latest</span>}
+                {isLatestDefault && <span class="cl-tag cl-tag-sm cl-tag-latest cl-latest-default">latest</span>}
+                {isLatestWhenRevealed && <span class="cl-tag cl-tag-sm cl-tag-latest cl-latest-flag">latest</span>}
               </div>
               <div class="changelog-date-new">{formatDate(entry.date)}</div>
             </div>
@@ -135,7 +145,8 @@ function formatDate(dateStr: string): string {
               ))}
             </div>
           </article>
-        ))}
+          );
+        })}
       </div>
     </section>
   </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1512,6 +1512,15 @@ a:not([class*="bg-"]):not([class*="btn"]):hover {
   align-items: start;
 }
 .changelog-entry-new:first-of-type { border-top: none; }
+
+/* Build-time-hidden changelog entries (in `site-hidden-versions` flag payload).
+   Revealed at runtime when the `site-show-v0-8` flag is enabled. The two
+   `latest` pills swap so that whichever entry is effectively first gets it. */
+.changelog-entry-new.cl-entry-hidden { display: none; }
+.cl-latest-flag { display: none !important; }
+html[data-flag-site-show-v0-8="on"] .changelog-entry-new.cl-entry-hidden { display: grid; }
+html[data-flag-site-show-v0-8="on"] .cl-latest-default { display: none !important; }
+html[data-flag-site-show-v0-8="on"] .cl-latest-flag { display: inline-flex !important; }
 .changelog-meta-new {
   position: sticky;
   top: 80px;


### PR DESCRIPTION
## Summary
- Renders both v0.7.3 (default) and v0.8.0 (flag-revealed) into the HTML at build time so the `site-show-v0-8` PostHog flag can swap between them at runtime — no rebuild needed
- Hero version chip and the changelog v0.8.0 entry are both gated on the same flag; default state stays safe (v0.7.3) for bots/no-JS visitors and people who have opted out of analytics
- PostHog flag `site-show-v0-8` already created (id 668512), inactive by default, 100% rollout when enabled

## How it works
- `version.ts`: new `getExpectedNextVersion()` returns hardcoded `0.8.0` (GitHub fetch can't return a tag that isn't there yet)
- `Hero.astro`: emits both texts as `data-version-text-default` / `data-version-text-flag` attributes
- `Layout.astro`: existing `onFeatureFlags` callback now also swaps `#hero-version` textContent based on whether `site-show-v0-8` is active
- `changelog.astro`: renders every entry, marks build-time-hidden entries with `cl-entry-hidden`, and pre-places a second "latest" pill that takes over when revealed
- `global.css`: hides `.cl-entry-hidden` by default; reveals under `html[data-flag-site-show-v0-8="on"]` and swaps which "latest" pill is visible

## Demo flow
```bash
bosshogg flag enable site-show-v0-8 -y    # reveal v0.8.0
bosshogg flag disable site-show-v0-8 -y   # hide again
```

## Cleanup when v0.8.0 actually ships
- Drop `EXPECTED_NEXT_VERSION` from `version.ts`
- Remove the `cl-latest-flag` / `cl-entry-hidden` CSS rules
- Drop `0.8.0` from the `site-hidden-versions` flag payload and from `FAILSAFE_HIDDEN`
- Delete the `site-show-v0-8` flag

## Test plan
- [ ] Default build: hero shows v0.7.3, changelog shows 0.7.3 as latest, no v0.8.0 entry visible
- [ ] After `bosshogg flag enable site-show-v0-8`: hero swaps to v0.8.0, changelog reveals v0.8.0 entry with "latest" pill, v0.7.3 loses its pill
- [ ] After `bosshogg flag disable site-show-v0-8`: state reverts on next page load / flag refresh
- [ ] View source on default state confirms v0.8.0 changelog entry is in the HTML (just CSS-hidden)
- [ ] Analytics opt-out users (`localStorage.ph_optout = '1'`) keep seeing the safe default

🤖 Generated with [Claude Code](https://claude.com/claude-code)